### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(name='PDPbox',
           'joblib',
           'psutil',
           'matplotlib==3.1.1',
-          'sklearn'
+          'scikit-learn'
       ],
       zip_safe=False)


### PR DESCRIPTION
scikit-learn has replaced the deprecated sklearn. original repo had a contribution to update this but it was never merged https://github.com/SauceCat/PDPbox/pull/77 